### PR TITLE
Add chai as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "set-protocol-utils",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "Common utilities for Set Protocol",
   "main": "dist/index.js",
   "typings": "dist/types/index.d.ts",
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/SetProtocol/set-protocol-utils#readme",
   "devDependencies": {
-    "chai": "^4.1.2",
     "tslint": "5.8.0",
     "typedoc": "^0.11.1",
     "typescript": "^2.9.2"
@@ -37,6 +36,7 @@
     "@types/node": "^8.0.53",
     "abi-decoder": "^1.0.9",
     "bignumber.js": "~4.1.0",
+    "chai": "^4.1.2",
     "ethereum-types": "^1.0.0",
     "ethereumjs-util": "^5.1.1",
     "ethers": "3.0.22",


### PR DESCRIPTION
setprotocol.js fails because this dependency isn't installed. it is used in logs.ts