### PR TITLE
Add ExchangeRedemptionParams + bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "set-protocol-utils",
-  "version": "1.0.0-beta.27",
+  "version": "1.0.0-beta.28",
   "description": "Common utilities for Set Protocol",
   "main": "dist/index.js",
   "typings": "dist/types/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export {
   Constants,
   ECSig,
   ExchangeIssueParams,
+  ExchangeRedemptionParams,
   ExchangeOrder,
   Exchanges,
   KyberTrade,

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,15 @@ export interface ExchangeIssueParams {
   requiredComponentAmounts: BigNumber[];
 }
 
+export interface ExchangeRedemptionParams {
+  setAddress: Address;
+  redemptionToken: Address;
+  redemptionTokenAmount: BigNumber;
+  quantity: BigNumber;
+  requiredComponents: Address[];
+  requiredComponentAmounts: BigNumber[];
+}
+
 export interface KyberTrade {
   destinationToken: Address;
   sourceTokenQuantity: BigNumber;


### PR DESCRIPTION
Added 

```export interface ExchangeRedemptionParams {
  setAddress: Address;
  redemptionToken: Address;
  redemptionTokenAmount: BigNumber;
  quantity: BigNumber;
  requiredComponents: Address[];
  requiredComponentAmounts: BigNumber[];
}
```

Didn't merge with ExchangeIssueParams as naming might have been confusing

@felix2feng could you publish an updated npm package?